### PR TITLE
RCOR-1469 - added permissions to delete Event Rule in RapticoreCrossAccountStack

### DIFF
--- a/RapticoreCrossAccountStack.json
+++ b/RapticoreCrossAccountStack.json
@@ -395,7 +395,9 @@
                   "Sid": "AllowPutRuleInSenderBus",
                   "Action": [
                     "events:PutRule",
-                    "events:PutTargets"
+                    "events:DeleteRule",
+                    "events:PutTargets",
+                    "events:RemoveTargets"
                   ],
                   "Resource": "*",
                   "Effect": "Allow"

--- a/RapticoreCrossAccountStack.yaml
+++ b/RapticoreCrossAccountStack.yaml
@@ -312,7 +312,9 @@ Resources:
               - Sid: AllowPutRuleInSenderBus
                 Action:
                   - events:PutRule
+                  - events:DeleteRule
                   - events:PutTargets
+                  - events:RemoveTargets
                 Resource: "*"
                 Effect: Allow
               - Sid: AllowIAMPassRoleForRuleTargetRole


### PR DESCRIPTION
added permissions to delete Event Rule in RapticoreCrossAccountStack