### PR TITLE
RCOR-1639: updated RapticoreCrossAccountStack delete Event Rule permission to apply to only RTTM rules

### DIFF
--- a/RapticoreCrossAccountStack.json
+++ b/RapticoreCrossAccountStack.json
@@ -395,11 +395,20 @@
                   "Sid": "AllowPutRuleInSenderBus",
                   "Action": [
                     "events:PutRule",
-                    "events:DeleteRule",
                     "events:PutTargets",
                     "events:RemoveTargets"
                   ],
                   "Resource": "*",
+                  "Effect": "Allow"
+                },
+                {
+                  "Sid": "AllowDeleteRuleInSenderBus",
+                  "Action": [
+                    "events:DeleteRule"
+                  ],
+                  "Resource": [
+                    "arn:aws:events:*:*:rule/RapticoreRTTM*"
+                  ],
                   "Effect": "Allow"
                 },
                 {

--- a/freemium/IAMRoleFreemiumCrossAccountStack.yaml
+++ b/freemium/IAMRoleFreemiumCrossAccountStack.yaml
@@ -305,10 +305,15 @@ Resources:
               - Sid: AllowPutRuleInSenderBus
                 Action:
                   - events:PutRule
-                  - events:DeleteRule
                   - events:PutTargets
                   - events:RemoveTargets
                 Resource: "*"
+                Effect: Allow
+              - Sid: AllowDeleteRuleInSenderBus
+                Action:
+                  - events:DeleteRule
+                Resource:
+                  - "arn:aws:events:*:*:rule/RapticoreRTTM*"
                 Effect: Allow
               - Sid: AllowIAMPassRoleForRuleTargetRole
                 Action:


### PR DESCRIPTION
reopened