### PR TITLE
RCOR-2763: add real per-tenant S3 buckets + pod-role versioning IAM (real-AWS local-dev pivot)

### DIFF
--- a/standard/EksClusterStack.yaml
+++ b/standard/EksClusterStack.yaml
@@ -345,9 +345,11 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:GetObject
+                  - s3:GetObjectVersion       # history bucket reads objects by versionId
                   - s3:PutObject
                   - s3:DeleteObject
                   - s3:ListBucket
+                  - s3:ListBucketVersions      # history bucket enumerates object versions
                 Resource:
                   - "arn:aws:s3:::vcs-content-*"
                   - "arn:aws:s3:::vcs-content-*/*"
@@ -357,6 +359,16 @@ Resources:
                   - "arn:aws:s3:::ore.c7n.remediation.policies/*"
                   - "arn:aws:s3:::rapticore-standard-tenants-postgres-db-backups"
                   - "arn:aws:s3:::rapticore-standard-tenants-postgres-db-backups/*"
+                  # App storage buckets — real AWS S3 (was LocalStack). Wildcards
+                  # cover every tenant's file/image/history/git-storage-<tenant>-<acct>.
+                  - "arn:aws:s3:::file-storage-*"
+                  - "arn:aws:s3:::file-storage-*/*"
+                  - "arn:aws:s3:::image-storage-*"
+                  - "arn:aws:s3:::image-storage-*/*"
+                  - "arn:aws:s3:::history-storage-*"
+                  - "arn:aws:s3:::history-storage-*/*"
+                  - "arn:aws:s3:::git-storage-*"
+                  - "arn:aws:s3:::git-storage-*/*"
               # Bedrock Access
               - Effect: Allow
                 Action:

--- a/standard/StandardStack.yaml
+++ b/standard/StandardStack.yaml
@@ -182,6 +182,65 @@ Resources:
         - Key: TenantId
           Value: !Ref TenantId
 
+  # App storage buckets — real AWS S3 (previously emulated in-cluster via
+  # LocalStack). The ${AWS::AccountId} suffix guarantees the otherwise-generic
+  # names are globally unique. history-storage is versioned (object history is
+  # keyed by S3 versionId; see glass-comb-api HistorySubscriber). The shared pod
+  # role grants <purpose>-storage-* (EksClusterStack ApplicationPodsRole).
+  FileStorageBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "file-storage-${TenantId}-${AWS::AccountId}"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      Tags:
+        - Key: TenantId
+          Value: !Ref TenantId
+
+  ImageStorageBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "image-storage-${TenantId}-${AWS::AccountId}"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      Tags:
+        - Key: TenantId
+          Value: !Ref TenantId
+
+  HistoryStorageBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "history-storage-${TenantId}-${AWS::AccountId}"
+      VersioningConfiguration:
+        Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      Tags:
+        - Key: TenantId
+          Value: !Ref TenantId
+
+  GitStorageBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "git-storage-${TenantId}-${AWS::AccountId}"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      Tags:
+        - Key: TenantId
+          Value: !Ref TenantId
+
   #####
   # SQS Queue resources
   #####
@@ -723,6 +782,22 @@ Outputs:
   VcsContentBucketName:
     Description: Name of the VCS content S3 bucket
     Value: !Ref VcsContentBucket
+
+  FileStorageBucketName:
+    Description: Name of the file storage S3 bucket
+    Value: !Ref FileStorageBucket
+
+  ImageStorageBucketName:
+    Description: Name of the image storage S3 bucket
+    Value: !Ref ImageStorageBucket
+
+  HistoryStorageBucketName:
+    Description: Name of the (versioned) history storage S3 bucket
+    Value: !Ref HistoryStorageBucket
+
+  GitStorageBucketName:
+    Description: Name of the git storage S3 bucket
+    Value: !Ref GitStorageBucket
 
   VcsTriggerAppSecQueueURL:
     Description: URL of the VCS trigger appsec queue


### PR DESCRIPTION
Part of **RCOR-2763** — retiring the in-cluster LocalStack emulator so S3+SQS are real AWS for dev/prod tenants and local developers.

## StandardStack.yaml (+4 buckets, +4 outputs, additive)
- `FileStorageBucket`, `ImageStorageBucket`, `GitStorageBucket` — `<purpose>-storage-${TenantId}-${AWS::AccountId}`
- `HistoryStorageBucket` — same, **VersioningConfiguration: Enabled** (object history keyed by versionId)
- All four: full `PublicAccessBlockConfiguration` + TenantId tag; 4 matching `*BucketName` Outputs

## EksClusterStack.yaml (pod-role IAM, additive)
- `ApplicationPodsRole` gains `s3:GetObjectVersion` + `s3:ListBucketVersions` and the four `{file,image,history,git}-storage-*` bucket-ARN wildcards

Purely additive (no deletions). The Freemium chart derives these bucket names and the glass-comb-api reads/writes them once LocalStack is gone.

**Deploy order:** EksClusterStack (IAM) → StandardStack (buckets), dev tenant first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)