### PR TITLE
RCOR-2767 feat(iam): add ce:GetCostAndUsageWithResources to cross-account role

### DIFF
--- a/RapticoreCrossAccountStack.json
+++ b/RapticoreCrossAccountStack.json
@@ -177,6 +177,7 @@
             {
               "Action": [
                 "ce:GetCostAndUsage",
+                "ce:GetCostAndUsageWithResources",
                 "ce:GetCostForecast"
               ],
               "Effect": "Allow",

--- a/RapticoreCrossAccountStack.yaml
+++ b/RapticoreCrossAccountStack.yaml
@@ -140,6 +140,7 @@ Resources:
             Sid: AllowEBSReadOnly
           - Action:
               - ce:GetCostAndUsage
+              - ce:GetCostAndUsageWithResources
               - ce:GetCostForecast
             Effect: Allow
             Resource: '*'

--- a/freemium/IAMRoleFreemiumCrossAccountStack.yaml
+++ b/freemium/IAMRoleFreemiumCrossAccountStack.yaml
@@ -133,6 +133,7 @@ Resources:
             Sid: AllowEBSReadOnly
           - Action:
               - ce:GetCostAndUsage
+              - ce:GetCostAndUsageWithResources
               - ce:GetCostForecast
             Effect: Allow
             Resource: '*'

--- a/rapticore_extractor_addon.json
+++ b/rapticore_extractor_addon.json
@@ -157,6 +157,7 @@
     {
       "Action": [
         "ce:GetCostAndUsage",
+        "ce:GetCostAndUsageWithResources",
         "ce:GetCostForecast"
       ],
       "Effect": "Allow",


### PR DESCRIPTION
Grants the cross-account scan role the separate CE action needed for AWS per-resource cost in the consolidated Cloud Cost page. Added to all four role templates (RapticoreCrossAccountStack.json/.yaml,
freemium/IAMRoleFreemiumCrossAccountStack.yaml, rapticore_extractor_addon.json). Consumed by cloud-inventory's Cost Explorer collector, gated behind CLOUD_INVENTORY_AWS_RESOURCE_COSTS + the account's Cost Management resource-level-data opt-in.