### PR TITLE
RCOR-2774 chore(eks): disable control-plane log types in IaC to match the live clusters

### DIFF
--- a/standard/EksClusterStack.yaml
+++ b/standard/EksClusterStack.yaml
@@ -201,13 +201,23 @@ Resources:
         SubnetIds: !Ref SubnetIds
         EndpointPublicAccess: !Ref EndpointPublicAccess
         EndpointPrivateAccess: !Ref EndpointPrivateAccess
+      # Control-plane logs to CloudWatch are DISABLED (2026-07-26, cost).
+      # They were ~$63/mo of USW2-VendedLog-Bytes — the single largest line of
+      # the CloudWatch bill — with no consumer: application logs ship to Loki
+      # via the aws-for-fluent-bit DaemonSet (loki output only), not CloudWatch.
+      #
+      # An EMPTY EnabledTypes array is the documented way to disable all types
+      # ("All log types are disabled if the array is empty"). The Logging /
+      # ClusterLogging / EnabledTypes keys must be RETAINED, not deleted: AWS
+      # requires them on update if the previous template had them. Applied live
+      # to both clusters via `aws eks update-cluster-config`; this keeps a
+      # future stack update from silently re-enabling them.
+      #
+      # To re-enable (e.g. if compliance wants the audit trail back), list the
+      # types here again — `Update requires: No interruption`.
       Logging:
         ClusterLogging:
-          EnabledTypes:
-            - Type: api
-            - Type: audit
-            - Type: authenticator
-            - Type: scheduler
+          EnabledTypes: []
       Tags:
         - Key: Name
           Value: !Ref ClusterName


### PR DESCRIPTION
EKS control-plane logging was **~$63/mo** of `USW2-VendedLog-Bytes` — the largest line of the CloudWatch bill — with no consumer: application logs ship to Loki via the `aws-for-fluent-bit` DaemonSet, never to CloudWatch.

Already disabled **live** on both `rapticore-eks-dev` and `rapticore-eks-prod` (2026-07-26, `aws eks update-cluster-config`). This makes the IaC match, so a future stack update cannot silently re-enable it and bring the cost back.

An empty `EnabledTypes` array is the documented way to disable all types. The `Logging`/`ClusterLogging`/`EnabledTypes` keys are deliberately **retained rather than deleted** — AWS requires them on update if the previous template had them. `Update requires: No interruption`.

> [!NOTE]
> This drops the control-plane **audit** trail, which SOC 2 / PCI-style frameworks generally expect. Re-enabling is a one-line revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)