### PR TITLE
RCOR-2776 fix(iam): scope the Azure OIDC ensure-resource permissions correctly

### DIFF
--- a/standard/StandardStack.yaml
+++ b/standard/StandardStack.yaml
@@ -106,18 +106,36 @@ Resources:
             Version: "2012-10-17"
             Statement:
               # Create/List cannot be scoped to a resource that may not exist yet.
+              #
+              # Get is here too, and MUST be "*": _find_existing() resolves the
+              # provider by listing every provider in the account and reading each
+              # one's Url. That necessarily calls Get on providers belonging to
+              # other things — notably the EKS cluster's own OIDC provider
+              # (oidc.eks.<region>.amazonaws.com/id/...). Scoping Get to just the
+              # Azure ARN made the scan fail with AccessDenied on the first
+              # unrelated provider it reached (2026-07-27, rapticore-azuretest).
+              # Get is read-only metadata (url, client ids, thumbprints), so "*"
+              # is an acceptable read scope; the MUTATING calls stay scoped below.
               - Effect: Allow
                 Action:
                   - iam:CreateOpenIDConnectProvider
                   - iam:ListOpenIDConnectProviders
+                  - iam:GetOpenIDConnectProvider
                 Resource: "*"
-              # Everything else is scoped to this Azure tenant's provider only.
+              # Mutating calls are scoped to this Azure tenant's provider only.
+              #
+              # Both slash forms are listed on purpose: the Url we create is
+              # "https://sts.windows.net/<tid>/" (trailing slash), and IAM keeps
+              # that slash in the ARN — the live dev provider really is
+              # ".../oidc-provider/sts.windows.net/<tid>/". A resource pattern
+              # without the trailing slash silently matches nothing.
               - Effect: Allow
                 Action:
-                  - iam:GetOpenIDConnectProvider
                   - iam:AddClientIDToOpenIDConnectProvider
                   - iam:TagOpenIDConnectProvider
-                Resource: !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/sts.windows.net/${AzureTenantId}"
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/sts.windows.net/${AzureTenantId}"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/sts.windows.net/${AzureTenantId}/"
 
   AzureOidcProviderFunction:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
Two defects in the `ManageAzureOidcProvider` policy, both hit on the **first real run** (`rapticore-azuretest`, 2026-07-27 → `ROLLBACK_COMPLETE`).

**1. `iam:GetOpenIDConnectProvider` was scoped too narrowly.** `_find_existing()` resolves the provider by listing **every** provider in the account and reading each one's `Url`. It therefore calls `Get` on unrelated providers — it reached the **EKS cluster's own** OIDC provider (`oidc.eks.us-west-2.amazonaws.com/id/…`) and failed with `AccessDenied`. `Get` is read-only metadata, so it moves to `Resource: "*"` alongside `List`; the mutating calls stay scoped.

**2. The scoped ARN omitted the trailing slash.** The `Url` we create is `https://sts.windows.net/<tid>/` and IAM preserves that slash — the live provider really is `…/oidc-provider/sts.windows.net/<tid>/`. A pattern without it matches nothing, so `AddClientID`/`Tag` would have been denied on the very next call. Both slash forms are now listed explicitly.

## Verification

Stack now reaches `CREATE_COMPLETE`, and the handler logs:
```
Adopted existing OIDC provider arn:aws:iam::343027753149:oidc-provider/sts.windows.net/ad5bb94c-…/
```
proving two Rapticore tenants can share one Azure tenant — the point of RCOR-2773.

> [!NOTE]
> The failed first attempt confirmed the safety property too: dev's OIDC provider was **never at risk**. During rollback the handler logged `Delete: preserving shared OIDC provider for reuse` and dev's provider survived intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)